### PR TITLE
Add custom display to ParserException in order to handle newlines correctly

### DIFF
--- a/src/core/parsers.jl
+++ b/src/core/parsers.jl
@@ -196,6 +196,11 @@ function once(channel)
     throw(ParserException("cannot parse"))
 end
 
+# Custom display for ParserCombinator.ParserException to render newlines properly
+function Base.showerror(io::IO, e::ParserException)
+    print(io, e.msg)
+end
+
 function make_one(config; kargs_make...)
     function single_result(source, matcher::Matcher; kargs_parse...)
         once(make(config, source, matcher; kargs_make..., kargs_parse...)[2])


### PR DESCRIPTION
See the discussion in https://github.com/SciML/BaseModelica.jl/pull/48